### PR TITLE
Fix base path for GitHub Pages deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+

--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
   </head>
   <body class="bg-neutral-950 text-neutral-100">
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { readFileSync } from 'fs'
 
-// Cambia 'tuner-lab' por el nombre de tu repo si usas GitHub Pages
-export default defineConfig({
+// Derive base path from package.json name for GitHub Pages deployment
+const { name } = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf-8')
+)
+
+export default defineConfig(({ command }) => ({
   plugins: [react()],
-  base: '/tuner-lab/',
-})
+  base: command === 'build' ? `/${name}/` : '/',
+}))
+


### PR DESCRIPTION
## Summary
- derive Vite base path from package name for production builds
- load main module via relative path so repo-hosted site works
- ignore build and node modules artifacts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8b0c079ec833394c404749ecd16d7