### PR TITLE
fix: serve main module with correct mime

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
   </head>
   <body class="bg-neutral-950 text-neutral-100">
     <div id="root"></div>
-    <script type="module" src="./src/main.tsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure main module imports use an absolute path so Vite serves JS with correct MIME

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8b1b30f8883338574ba0cb79b2734