### PR TITLE
feat: add static server for web deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist"
+    "deploy": "gh-pages -d dist",
+    "start": "node server.mjs"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,43 @@
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distDir = join(__dirname, 'dist');
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.svg': 'image/svg+xml'
+};
+
+const server = createServer(async (req, res) => {
+  const urlPath = req.url === '/' ? '/index.html' : req.url;
+  const filePath = join(distDir, urlPath);
+  try {
+    const data = await readFile(filePath);
+    const ext = extname(filePath);
+    res.writeHead(200, { 'Content-Type': mimeTypes[ext] || 'application/octet-stream' });
+    res.end(data);
+  } catch {
+    // Fallback to index.html for SPA routes
+    try {
+      const data = await readFile(join(distDir, 'index.html'));
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(data);
+    } catch {
+      res.writeHead(404);
+      res.end('Not found');
+    }
+  }
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+  console.log(`Servidor iniciado en http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- add minimal Node server to serve built assets
- expose `npm start` script to launch server

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `node server.mjs & sleep 1; curl -I localhost:3000; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_68b8dc3702e48333b45a53d8a1b016d8