### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tuner Lab · Armónicos & Temperamentos</title>
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
   </head>
   <body class="bg-neutral-950 text-neutral-100">
     <div id="root"></div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { readFileSync } from 'fs'
 
-// Derive base path from package.json name for GitHub Pages deployment
-const { name } = JSON.parse(
-  readFileSync(new URL('./package.json', import.meta.url), 'utf-8')
-)
-
+// Explicit base path ensures assets load correctly on GitHub Pages
 export default defineConfig(({ command }) => ({
   plugins: [react()],
-  base: command === 'build' ? `/${name}/` : '/',
+  base: command === 'build' ? '/tuner-lab/' : '/',
 }))
 


### PR DESCRIPTION
## Summary
- ensure Vite uses '/tuner-lab/' base for builds
- use relative favicon path so icon loads on GitHub Pages

## Testing
- `npm test` (fails: Missing script: test)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8df27c8248333983ff6a20d5390dc