### PR TITLE
fix: correct MIME types and base path

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -13,11 +13,18 @@ const mimeTypes = {
   '.json': 'application/json',
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
-  '.svg': 'image/svg+xml'
+  '.svg': 'image/svg+xml',
+  '.ts': 'text/javascript',
+  '.tsx': 'text/javascript'
 };
 
+const basePath = '/tuner-lab';
+
 const server = createServer(async (req, res) => {
-  const urlPath = req.url === '/' ? '/index.html' : req.url;
+  let urlPath = req.url === '/' ? '/index.html' : req.url;
+  if (urlPath.startsWith(basePath)) {
+    urlPath = urlPath.slice(basePath.length) || '/index.html';
+  }
   const filePath = join(distDir, urlPath);
   try {
     const data = await readFile(filePath);


### PR DESCRIPTION
## Summary
- serve TypeScript files with a JavaScript MIME type
- strip configured base path so built assets resolve correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `curl -I http://localhost:3000/tuner-lab/assets/index-D_Kng2BN.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8e042f2888333b1cfbf2423b4afe8