### PR TITLE
fix: correct mime type handling

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -1,7 +1,7 @@
 import { createServer } from 'node:http';
 import { readFile } from 'node:fs/promises';
 import { extname, join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, URL } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const distDir = join(__dirname, 'dist');
@@ -21,14 +21,19 @@ const mimeTypes = {
 const basePath = '/tuner-lab';
 
 const server = createServer(async (req, res) => {
-  let urlPath = req.url === '/' ? '/index.html' : req.url;
+  // Parse the incoming URL to ignore query strings when resolving files
+  const { pathname } = new URL(req.url, 'http://localhost');
+
+  let urlPath = pathname === '/' ? '/index.html' : pathname;
   if (urlPath.startsWith(basePath)) {
     urlPath = urlPath.slice(basePath.length) || '/index.html';
   }
+
   const filePath = join(distDir, urlPath);
+
   try {
     const data = await readFile(filePath);
-    const ext = extname(filePath);
+    const ext = extname(filePath).toLowerCase();
     res.writeHead(200, { 'Content-Type': mimeTypes[ext] || 'application/octet-stream' });
     res.end(data);
   } catch {


### PR DESCRIPTION
## Summary
- robustly parse request URLs and normalize extensions before determining MIME types
- prevent module scripts from loading with `application/octet-stream` fallback

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8e1b7cce88333b2cbe4a99574b2f0